### PR TITLE
fix: searchbar not visible in android

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -69,6 +69,8 @@ const styles = StyleSheet.create({
   },
   input: {
     flex: 1,
+    padding: 0,
+    fontSize: 14,
   },
 });
 


### PR DESCRIPTION
## Summary
- Solved issue where some androids didn't show the text inside the searchbar