### PR TITLE
fix: creating a session only when there's no uri

### DIFF
--- a/src/components/WalletConnectModal.tsx
+++ b/src/components/WalletConnectModal.tsx
@@ -12,6 +12,7 @@ import { ClientCtrl } from '../controllers/ClientCtrl';
 import { ToastCtrl } from '../controllers/ToastCtrl';
 import { RouterCtrl } from '../controllers/RouterCtrl';
 import { ConfigCtrl } from '../controllers/ConfigCtrl';
+import { WcConnectionCtrl } from '../controllers/WcConnectionCtrl';
 import { useOrientation } from '../hooks/useOrientation';
 import type { ConfigCtrlState, ThemeCtrlState } from '../types/controllerTypes';
 import type { IProviderMetadata, ISessionParams } from '../types/coreTypes';
@@ -60,20 +61,26 @@ export function WalletConnectModal(config: Props) {
   };
 
   const onSessionError = async () => {
+    WcConnectionCtrl.resetConnection();
     ConfigCtrl.setRecentWalletDeepLink(undefined);
-    ModalCtrl.close();
-    ToastCtrl.openToast('Unable to create the session', 'error');
+    ToastCtrl.openToast('Unable to connect', 'error');
+
+    // create a new pairing uri
+    onConnect();
   };
 
   const onConnect = async () => {
     const provider = ClientCtrl.provider();
+    const pairingUri = WcConnectionCtrl.state.pairingUri;
+
     try {
       if (!provider) throw new Error('Provider not initialized');
 
-      if (!isConnected) {
+      if (!isConnected && !pairingUri) {
         const session = await provider.connect(
           config?.sessionParams || defaultSessionParams
         );
+
         if (session) {
           onSessionCreated(session);
         }

--- a/src/constants/Config.ts
+++ b/src/constants/Config.ts
@@ -1,8 +1,10 @@
+import type { ISessionParams } from '../types/coreTypes';
+
 const DEFAULT_CHAINS = ['eip155:1'];
 const REQUIRED_METHODS = ['eth_sendTransaction', 'personal_sign'];
 const REQUIRED_EVENTS = ['chainChanged', 'accountsChanged'];
 
-export const defaultSessionParams = {
+export const defaultSessionParams: ISessionParams = {
   namespaces: {
     eip155: {
       methods: REQUIRED_METHODS,

--- a/src/controllers/ConfigCtrl.ts
+++ b/src/controllers/ConfigCtrl.ts
@@ -5,6 +5,7 @@ import type { ConfigCtrlState } from '../types/controllerTypes';
 // -- initial state ------------------------------------------------ //
 const state = proxy<ConfigCtrlState>({
   projectId: '',
+  sessionParams: undefined,
   recentWalletDeepLink: undefined,
   providerMetadata: undefined,
   explorerRecommendedWalletIds: undefined,
@@ -31,13 +32,17 @@ export const ConfigCtrl = {
   },
 
   setConfig(config: Partial<ConfigCtrlState>) {
-    const { projectId, providerMetadata } = config;
+    const { projectId, providerMetadata, sessionParams } = config;
     if (projectId && projectId !== state.projectId) {
       state.projectId = projectId;
     }
 
     if (providerMetadata && state.providerMetadata !== providerMetadata) {
       state.providerMetadata = providerMetadata;
+    }
+
+    if (sessionParams && sessionParams !== state.sessionParams) {
+      state.sessionParams = sessionParams;
     }
 
     state.explorerRecommendedWalletIds = config.explorerRecommendedWalletIds;

--- a/src/controllers/ModalCtrl.ts
+++ b/src/controllers/ModalCtrl.ts
@@ -5,6 +5,7 @@ import { ClientCtrl } from './ClientCtrl';
 import { OptionsCtrl } from './OptionsCtrl';
 import { AccountCtrl } from './AccountCtrl';
 import { RouterCtrl } from './RouterCtrl';
+import { WcConnectionCtrl } from './WcConnectionCtrl';
 
 // -- types -------------------------------------------------------- //
 export interface OpenOptions {
@@ -25,6 +26,7 @@ export const ModalCtrl = {
       const { isDataLoaded } = OptionsCtrl.state;
       const { isConnected } = AccountCtrl.state;
       const { initialized } = ClientCtrl.state;
+      WcConnectionCtrl.setPairingEnabled(true);
 
       if (isConnected) {
         // If already connected, do nothing

--- a/src/controllers/WcConnectionCtrl.ts
+++ b/src/controllers/WcConnectionCtrl.ts
@@ -4,6 +4,7 @@ import type { WcConnectionCtrlState } from '../types/controllerTypes';
 // -- initial state ------------------------------------------------ //
 const state = proxy<WcConnectionCtrlState>({
   pairingUri: '',
+  pairingEnabled: false,
   pairingError: false,
 });
 
@@ -19,8 +20,13 @@ export const WcConnectionCtrl = {
     state.pairingError = pairingError;
   },
 
+  setPairingEnabled(enabled: WcConnectionCtrlState['pairingEnabled']) {
+    state.pairingEnabled = enabled;
+  },
+
   resetConnection() {
     state.pairingUri = '';
     state.pairingError = false;
+    state.pairingEnabled = false;
   },
 };

--- a/src/hooks/useConfigure.ts
+++ b/src/hooks/useConfigure.ts
@@ -46,6 +46,12 @@ export function useConfigure(config: Props) {
     WcConnectionCtrl.setPairingUri(uri);
   }, []);
 
+  useEffect(() => {
+    if (!projectId) {
+      Alert.alert('Error', 'projectId not found');
+    }
+  }, [projectId]);
+
   /**
    * Set theme mode
    */

--- a/src/hooks/useConnectionHandler.ts
+++ b/src/hooks/useConnectionHandler.ts
@@ -17,7 +17,7 @@ const FOUR_MIN_MS = 240_000;
 export function useConnectionHandler() {
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
   const { isConnected } = useSnapshot(AccountCtrl.state);
-  const { pairingEnabled } = useSnapshot(WcConnectionCtrl.state);
+  const { pairingEnabled, pairingUri } = useSnapshot(WcConnectionCtrl.state);
   const { provider } = useSnapshot(ClientCtrl.state);
   const { sessionParams } = useSnapshot(ConfigCtrl.state);
 
@@ -59,10 +59,10 @@ export function useConnectionHandler() {
   }, [isConnected, provider, sessionParams, pairingEnabled]);
 
   useEffect(() => {
-    if (provider && !isConnected && pairingEnabled) {
+    if (provider && !isConnected && pairingEnabled && !pairingUri) {
       connectAndWait();
     }
-  }, [provider, connectAndWait, isConnected, pairingEnabled]);
+  }, [provider, connectAndWait, isConnected, pairingEnabled, pairingUri]);
 
   return null;
 }

--- a/src/hooks/useConnectionHandler.ts
+++ b/src/hooks/useConnectionHandler.ts
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { useSnapshot } from 'valtio';
+
+import { AccountCtrl } from '../controllers/AccountCtrl';
+import { WcConnectionCtrl } from '../controllers/WcConnectionCtrl';
+import { ClientCtrl } from '../controllers/ClientCtrl';
+import { defaultSessionParams } from '../constants/Config';
+import { ConfigCtrl } from '../controllers/ConfigCtrl';
+import type { ISessionParams } from '../types/coreTypes';
+import type { SessionTypes } from '@walletconnect/types';
+import { setDeepLinkWallet } from '../utils/StorageUtil';
+import { ModalCtrl } from '../controllers/ModalCtrl';
+import { ToastCtrl } from '../controllers/ToastCtrl';
+
+const FOUR_MIN_MS = 240_000;
+
+export function useConnectionHandler() {
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const { isConnected } = useSnapshot(AccountCtrl.state);
+  const { pairingEnabled } = useSnapshot(WcConnectionCtrl.state);
+  const { provider } = useSnapshot(ClientCtrl.state);
+  const { sessionParams } = useSnapshot(ConfigCtrl.state);
+
+  const onSessionCreated = async (session: SessionTypes.Struct) => {
+    WcConnectionCtrl.setPairingEnabled(false);
+    ClientCtrl.setSessionTopic(session.topic);
+    const deepLink = ConfigCtrl.getRecentWalletDeepLink();
+    try {
+      if (deepLink) {
+        await setDeepLinkWallet(deepLink);
+        ConfigCtrl.setRecentWalletDeepLink(undefined);
+      }
+      AccountCtrl.getAccount();
+      ModalCtrl.close();
+    } catch (error) {
+      ToastCtrl.openToast("Couldn't save deeplink", 'error');
+    }
+  };
+
+  const connectAndWait = useCallback(async () => {
+    try {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+
+      if (!isConnected && pairingEnabled) {
+        timeoutRef.current = setTimeout(connectAndWait, FOUR_MIN_MS);
+        const session = await provider!.connect(
+          (sessionParams as ISessionParams) ?? defaultSessionParams
+        );
+
+        if (session) {
+          onSessionCreated(session);
+        }
+      }
+    } catch (error) {
+      WcConnectionCtrl.setPairingUri('');
+      ConfigCtrl.setRecentWalletDeepLink(undefined);
+      ToastCtrl.openToast('Connection request declined', 'error');
+    }
+  }, [isConnected, provider, sessionParams, pairingEnabled]);
+
+  useEffect(() => {
+    if (provider && !isConnected && pairingEnabled) {
+      connectAndWait();
+    }
+  }, [provider, connectAndWait, isConnected, pairingEnabled]);
+
+  return null;
+}

--- a/src/types/controllerTypes.ts
+++ b/src/types/controllerTypes.ts
@@ -1,4 +1,4 @@
-import type { IProviderMetadata, IProvider } from './coreTypes';
+import type { IProviderMetadata, IProvider, ISessionParams } from './coreTypes';
 
 // -- ClientCtrl ------------------------------------------- //
 export interface ClientCtrlState {
@@ -10,6 +10,7 @@ export interface ClientCtrlState {
 // -- ConfigCtrl ------------------------------------------- //
 export interface ConfigCtrlState {
   projectId: string;
+  sessionParams?: ISessionParams;
   recentWalletDeepLink?: string;
   providerMetadata?: IProviderMetadata;
   explorerRecommendedWalletIds?: string[] | 'NONE';
@@ -35,6 +36,7 @@ export interface AccountCtrlState {
 // -- WcConnectionCtrl ------------------------------------- //
 export interface WcConnectionCtrlState {
   pairingUri: string;
+  pairingEnabled: boolean;
   pairingError: boolean;
 }
 


### PR DESCRIPTION
## Summary
- Checking for existing pairing uri before creating a new one
- Moved session logic to a new hook
- Creating a new pairing after 4 mins of inactivity


Closes https://github.com/WalletConnect/modal-react-native/issues/37