### PR TITLE
fix: solved issues with explorer and excluded wallet ids

### DIFF
--- a/src/controllers/ModalCtrl.ts
+++ b/src/controllers/ModalCtrl.ts
@@ -6,6 +6,8 @@ import { OptionsCtrl } from './OptionsCtrl';
 import { AccountCtrl } from './AccountCtrl';
 import { RouterCtrl } from './RouterCtrl';
 import { WcConnectionCtrl } from './WcConnectionCtrl';
+import { ConfigCtrl } from './ConfigCtrl';
+import { CoreUtil } from '../utils/CoreUtil';
 
 // -- types -------------------------------------------------------- //
 export interface OpenOptions {
@@ -26,6 +28,14 @@ export const ModalCtrl = {
       const { isDataLoaded } = OptionsCtrl.state;
       const { isConnected } = AccountCtrl.state;
       const { initialized } = ClientCtrl.state;
+      const { explorerRecommendedWalletIds, explorerExcludedWalletIds } =
+        ConfigCtrl.state;
+
+      const explorerDisabled =
+        explorerRecommendedWalletIds === 'NONE' ||
+        (explorerExcludedWalletIds === 'ALL' &&
+          !CoreUtil.isArray(explorerRecommendedWalletIds));
+
       WcConnectionCtrl.setPairingEnabled(true);
 
       if (isConnected) {
@@ -33,6 +43,8 @@ export const ModalCtrl = {
         return;
       } else if (options?.route) {
         RouterCtrl.replace(options.route);
+      } else if (explorerDisabled) {
+        RouterCtrl.replace('Qrcode');
       } else {
         RouterCtrl.replace('ConnectWallet');
       }

--- a/src/views/InitialExplorer.tsx
+++ b/src/views/InitialExplorer.tsx
@@ -9,6 +9,7 @@ import type { Listing } from '../types/controllerTypes';
 import { RouterCtrl } from '../controllers/RouterCtrl';
 import { OptionsCtrl } from '../controllers/OptionsCtrl';
 import { WcConnectionCtrl } from '../controllers/WcConnectionCtrl';
+import { ConfigCtrl } from '../controllers/ConfigCtrl';
 import type { RouterProps } from '../types/routerTypes';
 import useTheme from '../hooks/useTheme';
 import { DataUtil } from '../utils/DataUtil';
@@ -17,10 +18,14 @@ function InitialExplorer({ isPortrait }: RouterProps) {
   const Theme = useTheme();
   const { isDataLoaded } = useSnapshot(OptionsCtrl.state);
   const { pairingUri } = useSnapshot(WcConnectionCtrl.state);
+  const { explorerExcludedWalletIds } = useSnapshot(ConfigCtrl.state);
   const wallets = DataUtil.getInitialWallets();
   const recentWallet = DataUtil.getRecentWallet();
   const loading = !isDataLoaded || !pairingUri;
   const viewHeight = isPortrait ? WALLET_FULL_HEIGHT * 2 : WALLET_FULL_HEIGHT;
+
+  const showViewAllButton =
+    wallets.length > 8 || explorerExcludedWalletIds !== 'ALL';
 
   return (
     <>
@@ -41,20 +46,22 @@ function InitialExplorer({ isPortrait }: RouterProps) {
             { height: viewHeight, backgroundColor: Theme.background1 },
           ]}
         >
-          {wallets.slice(0, 7).map((item: Listing) => (
+          {wallets.slice(0, showViewAllButton ? 7 : 8).map((item: Listing) => (
             <WalletItem
               walletInfo={item}
               key={item.id}
               isRecent={item.id === recentWallet?.id}
               currentWCURI={pairingUri}
-              style={isPortrait && styles.wallet}
+              style={isPortrait ? styles.portraitItem : styles.landscapeItem}
             />
           ))}
-          <ViewAllBox
-            onPress={() => RouterCtrl.push('WalletExplorer')}
-            wallets={wallets.slice(-4)}
-            style={isPortrait && styles.wallet}
-          />
+          {showViewAllButton && (
+            <ViewAllBox
+              onPress={() => RouterCtrl.push('WalletExplorer')}
+              wallets={wallets.slice(-4)}
+              style={isPortrait ? styles.portraitItem : styles.landscapeItem}
+            />
+          )}
         </View>
       )}
     </>
@@ -65,11 +72,13 @@ const styles = StyleSheet.create({
   explorerContainer: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    justifyContent: 'center',
     alignItems: 'center',
   },
-  wallet: {
+  portraitItem: {
     width: '25%',
+  },
+  landscapeItem: {
+    width: '12.5%',
   },
 });
 


### PR DESCRIPTION
## Summary
* Showing only `explorerRecommendedWallets` if `explorerExcludedWalletIds === 'ALL'`
* Hide "View All" button if there's no more wallets to show
* Respect `explorerRecommendedWalletsIds` order

## Screenshots
#### Case 1
`explorerExcludedWalletIds === 'ALL'` & `9 explorerRecommendedWalletsIds`

https://github.com/WalletConnect/modal-react-native/assets/25931366/4c7d7165-90ba-43c4-b7d2-dd6e75b64828

#### Case 2
`explorerExcludedWalletIds === 'ALL'` & `3 explorerRecommendedWalletsIds`

https://github.com/WalletConnect/modal-react-native/assets/25931366/695969d6-eef0-4d89-a2b7-ab95977418ed

#### Case 3
`9 explorerRecommendedWalletsIds`

https://github.com/WalletConnect/modal-react-native/assets/25931366/e5a93a1f-5b9d-4f74-b2f9-50081000837e

#### Case 4
`3 explorerRecommendedWalletsIds`

https://github.com/WalletConnect/modal-react-native/assets/25931366/d0d4a194-2440-4c34-9f98-f03fe13825f2

#### Case 5
`explorerExcludedWalletIds === 'ALL'`

https://github.com/WalletConnect/modal-react-native/assets/25931366/9a1eca7e-8952-47b2-b64a-1dd3a7c89d6e

#### Case 6
`explorerRecommendedWalletIds === 'NONE'`

https://github.com/WalletConnect/modal-react-native/assets/25931366/adb97bae-f3a8-4b82-b3ba-abd8ffac1f78

#### Case 7
No params
 
https://github.com/WalletConnect/modal-react-native/assets/25931366/d78a06dd-d33f-45fe-8f86-48f5e5a7bf1d


## Related issue
https://github.com/WalletConnect/modal-react-native/issues/68

## Other known issues: 
* Initial view height is not adjusting correctly if there's just one row of wallets
* Lack of animation if modal directly opens in QR View