### PR TITLE
fix: save right wallet link

### DIFF
--- a/src/hooks/useConnectionHandler.ts
+++ b/src/hooks/useConnectionHandler.ts
@@ -25,19 +25,15 @@ export function useConnectionHandler() {
     WcConnectionCtrl.setPairingError(false);
     WcConnectionCtrl.setPairingEnabled(false);
     ClientCtrl.setSessionTopic(session.topic);
-    const saveDeepLink = RouterCtrl.state.view !== 'Qrcode';
+    const clearDeepLink = RouterCtrl.state.view === 'Qrcode';
+
     try {
-      const recentWallet = ConfigCtrl.getRecentWallet();
-      if (saveDeepLink && recentWallet?.mobile) {
-        await StorageUtil.setDeepLinkWallet(
-          recentWallet.mobile.native || recentWallet.mobile.universal
-        );
+      if (clearDeepLink) {
+        await StorageUtil.removeDeepLinkWallet();
       }
       AccountCtrl.getAccount();
       ModalCtrl.close();
-    } catch (error) {
-      console.info('Unable to save deeplink');
-    }
+    } catch (error) {}
   };
 
   const connectAndWait = useCallback(async () => {

--- a/src/utils/ExplorerUtil.ts
+++ b/src/utils/ExplorerUtil.ts
@@ -111,9 +111,9 @@ export const ExplorerUtil = {
         StorageUtil.setDeepLinkWallet(deepLink!);
         await Linking.openURL(nativeUrl).catch(() => {
           // Fallback to universal link
-          if (universalUrl) {
+          if (universalUrl && universalLink) {
             Linking.openURL(universalUrl);
-            StorageUtil.setDeepLinkWallet(universalLink!);
+            StorageUtil.setDeepLinkWallet(universalLink);
           } else {
             ToastCtrl.openToast('Unable to open the wallet', 'error');
           }

--- a/src/utils/ExplorerUtil.ts
+++ b/src/utils/ExplorerUtil.ts
@@ -12,6 +12,7 @@ import { ConfigCtrl } from '../controllers/ConfigCtrl';
 import { ToastCtrl } from '../controllers/ToastCtrl';
 import { isAppInstalled } from '../modules/AppInstalled';
 import { PLAYSTORE_REGEX } from '../constants/Platform';
+import { StorageUtil } from './StorageUtil';
 
 // -- Helpers -------------------------------------------------------
 const W3M_API = 'https://explorer-api.walletconnect.com';
@@ -107,20 +108,24 @@ export const ExplorerUtil = {
       const nativeUrl = CoreUtil.formatNativeUrl(deepLink, wcURI);
       const universalUrl = CoreUtil.formatUniversalUrl(universalLink, wcURI);
       if (nativeUrl) {
+        StorageUtil.setDeepLinkWallet(deepLink!);
         await Linking.openURL(nativeUrl).catch(() => {
           // Fallback to universal link
           if (universalUrl) {
             Linking.openURL(universalUrl);
+            StorageUtil.setDeepLinkWallet(universalLink!);
           } else {
             ToastCtrl.openToast('Unable to open the wallet', 'error');
           }
         });
       } else if (universalUrl) {
-        await Linking.openURL(universalUrl);
+        Linking.openURL(universalUrl);
+        StorageUtil.setDeepLinkWallet(universalLink!);
       } else {
         ToastCtrl.openToast('Unable to open the wallet', 'error');
       }
     } catch (error) {
+      StorageUtil.removeDeepLinkWallet();
       ToastCtrl.openToast('Unable to open the wallet', 'error');
     }
   },


### PR DESCRIPTION
## Summary
fix: save correct wallet link after successfully opening the wallet

In some cases, the dapp having a deeplink doesn't mean it works (e.g. 1inch on Android)