### PR TITLE
fix: add wallet image fade effect only on iOS

### DIFF
--- a/src/components/Image.tsx
+++ b/src/components/Image.tsx
@@ -1,5 +1,10 @@
 import { useRef } from 'react';
-import { Animated, ImageProps as NativeProps } from 'react-native';
+import {
+  Animated,
+  Image as NativeImage,
+  ImageProps as NativeProps,
+} from 'react-native';
+import { isIOS } from '../constants/Platform';
 
 export type ImageProps = Omit<NativeProps, 'source'> & {
   source: string;
@@ -8,6 +13,7 @@ export type ImageProps = Omit<NativeProps, 'source'> & {
 function Image({ source, style }: ImageProps) {
   const opacity = useRef(new Animated.Value(0));
 
+  // Fade in image on load for iOS. Android does this by default.
   const onLoadEnd = () => {
     Animated.timing(opacity.current, {
       toValue: 1,
@@ -16,12 +22,14 @@ function Image({ source, style }: ImageProps) {
     }).start();
   };
 
-  return (
+  return isIOS ? (
     <Animated.Image
       source={{ uri: source }}
       onLoadEnd={onLoadEnd}
       style={[{ opacity: opacity.current }, style]}
     />
+  ) : (
+    <NativeImage source={{ uri: source }} style={style} />
   );
 }
 


### PR DESCRIPTION
## Summary
Using native image to display wallet images on Android to solve an issue where in some cases the image won't render because of the animation.