### PR TITLE
fix: removed @ethersproject/shims as a required dependency of the sdk

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -11,6 +11,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
+    "@ethersproject/shims": "5.7.0",
     "@react-native-async-storage/async-storage": "1.18.2",
     "@react-native-community/netinfo": "9.3.10",
     "@walletconnect/encoding": "1.0.2",

--- a/example/src/screens/App.tsx
+++ b/example/src/screens/App.tsx
@@ -10,6 +10,7 @@ import {
   WalletConnectModal,
   useWalletConnectModal,
 } from '@walletconnect/modal-react-native';
+import '@ethersproject/shims';
 import { setStringAsync } from 'expo-clipboard';
 import { sessionParams, providerMetadata } from '../constants/Config';
 import { BlockchainActions } from '../components/BlockchainActions';

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1483,6 +1483,11 @@
     "@ethersproject/logger" "^5.7.0"
     hash.js "1.1.7"
 
+"@ethersproject/shims@5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/shims/-/shims-5.7.0.tgz#ee32e543418595774029c5ea6123ea8995e7e154"
+  integrity sha512-WeDptc6oAprov5CCN2LJ/6/+dC9gTonnkdAtLepm/7P5Z+3PRxS5NpfVWmOMs1yE4Vitl2cU8bOPWC0GvGSbVg==
+
 "@ethersproject/signing-key@5.7.0", "@ethersproject/signing-key@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.7.0.tgz#06b2df39411b00bc57c7c09b01d1e41cf1b16ab3"

--- a/package.json
+++ b/package.json
@@ -146,7 +146,6 @@
     ]
   },
   "dependencies": {
-    "@ethersproject/shims": "5.7.0",
     "@walletconnect/core": "2.10.4",
     "@walletconnect/react-native-compat": "2.10.4",
     "@walletconnect/universal-provider": "2.10.4",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,5 @@
 import 'react-native-get-random-values';
 import '@walletconnect/react-native-compat';
-import '@ethersproject/shims';
 import './config/animations';
 
 export { WalletConnectModal } from './components/WalletConnectModal';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1294,11 +1294,6 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.36.0.tgz#9837f768c03a1e4a30bd304a64fb8844f0e72efe"
   integrity sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg==
 
-"@ethersproject/shims@5.7.0":
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/shims/-/shims-5.7.0.tgz#ee32e543418595774029c5ea6123ea8995e7e154"
-  integrity sha512-WeDptc6oAprov5CCN2LJ/6/+dC9gTonnkdAtLepm/7P5Z+3PRxS5NpfVWmOMs1yE4Vitl2cU8bOPWC0GvGSbVg==
-
 "@evilmartians/lefthook@1.3.8":
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/@evilmartians/lefthook/-/lefthook-1.3.8.tgz#0a0b17c0de1874d0b1bad8281de279272a954b77"


### PR DESCRIPTION
### Summary
* Removed @ethersproject/shims dependency as is not needed for the sdk to work. Only projects that use ethers v5 should install this lib
* Added it in the example app only